### PR TITLE
Add timeout to Tohoku CSV read

### DIFF
--- a/cloud_functions/scrapers/area_data/utilities/tohokuden/TohokudenAreaScraper.py
+++ b/cloud_functions/scrapers/area_data/utilities/tohokuden/TohokudenAreaScraper.py
@@ -1,9 +1,6 @@
-import csv
-import requests
-import numpy as np
 import pandas as pd
-import datetime
 from ..UtilityAreaScraper import UtilityAreaScraper
+from func_timeout import func_timeout, FunctionTimedOut
 
 
 class TohokudenAreaScraper(UtilityAreaScraper):
@@ -68,11 +65,17 @@ class TohokudenAreaScraper(UtilityAreaScraper):
                 return translations[header]
             return header
 
+        def _get_file(url: str):
+            return pd.read_csv(
+                url, skiprows=0, encoding="cp932", dtype=dtypes)
+
         def _getTohokudenCSV(url):
             print("  -- getting:", url)
             try:
-                data = pd.read_csv(
-                    url, skiprows=0, encoding="cp932", dtype=dtypes)
+                data = func_timeout(5, _get_file, kwargs={"url": url})
+            except FunctionTimedOut as e:
+                print(f"Timeout on {url} - retrying...")
+                return _getTohokudenCSV(url)
             except Exception as e:
                 print("Caught error \"{error}\" at {url}".format(
                     error=e, url=url))

--- a/cloud_functions/scrapers/requirements.txt
+++ b/cloud_functions/scrapers/requirements.txt
@@ -7,6 +7,7 @@ cloudevents==0.3.0
 cycler==0.10.0
 Flask==1.1.2
 functions-framework==2.0.0
+func-timeout==4.3.5
 google-api-core==1.21.0
 google-auth==1.18.0
 google-auth-oauthlib==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ click==7.1.2
 cloudevents==0.3.0
 cycler==0.10.0
 Flask==1.1.2
+func-timeout==4.3.5
 functions-framework==2.0.0
 google-api-core==1.21.0
 google-auth==1.18.0


### PR DESCRIPTION
The Tohoku CSV reads timeout quite a lot, this PR fixes that with a retry